### PR TITLE
Fix AutoYaST schema

### DIFF
--- a/package/yast2-users.changes
+++ b/package/yast2-users.changes
@@ -3,6 +3,7 @@ Tue Sep 20 15:10:23 UTC 2016 - igonzalezsosa@suse.com
 
 - Prevent a potential security issue if the target authorized_keys
   file is not a regular file (related to FATE#319471)
+- Fix authorized_keys section of AutoYaST schema
 - 3.1.59
 
 -------------------------------------------------------------------

--- a/src/autoyast-rnc/users.rnc
+++ b/src/autoyast-rnc/users.rnc
@@ -35,8 +35,9 @@ user_defaults =
     umask?
   }
 
+# by default, AutoYaST exports list entries as 'listentry'
 authorized_key =
-  element authorized_key { text }
+  element authorized_key { text } | element listentry { text }
 
 authorized_keys =
   element authorized_keys {


### PR DESCRIPTION
While parsing `<authorized_keys>` section we allow the use of `<authorized_key>` and `<listentry>` (like [this one](https://github.com/yast/yast-services-manager/pull/78/files#diff-a2fda9ae7e167b33e6c68e0e25e6b40cR34).